### PR TITLE
style: refine lcd and key sequence styling

### DIFF
--- a/src/q_materialise/core.py
+++ b/src/q_materialise/core.py
@@ -278,13 +278,13 @@ QPushButton[class="info"] {{background-color: {INFO};
     color: {ON_INFO};}}
 
 /* Line edits and text fields */
-QLineEdit, QTextEdit, QPlainTextEdit {{background-color: {SURFACE};
+QLineEdit, QTextEdit, QPlainTextEdit, QKeySequenceEdit {{background-color: {SURFACE};
     color: {ON_SURFACE};
     border: 1px solid {PRIMARY_LIGHT};
     /* Match button corner radius for visual consistency */
     border-radius: 6px;
     padding: {PADDING_V}px {PADDING_H}px;}}
-QLineEdit:focus, QTextEdit:focus, QPlainTextEdit:focus {{border: 1px solid {PRIMARY};}}
+QLineEdit:focus, QTextEdit:focus, QPlainTextEdit:focus, QKeySequenceEdit:focus {{border: 1px solid {PRIMARY};}}
 
 /* Labels */
 QLabel {{color: {ON_SURFACE};}}
@@ -349,6 +349,7 @@ QLCDNumber {{background-color: {SURFACE_ELEV_1};
     color: {ON_SURFACE};
     border: 1px solid {OUTLINE};
     border-radius: 6px;
+    qproperty-segmentStyle: QLCDNumber::Flat;
     padding: {PADDING_V}px {PADDING_H}px;}}
 
 /* Menu bar */
@@ -631,13 +632,13 @@ QToolButton::menu-indicator {{width: 0; height: 0;
     margin: 0 8px 0 8px;}}
 
 /* Line edits & text fields ------------------------------------------------ */
-QLineEdit, QTextEdit, QPlainTextEdit, QSpinBox, QDoubleSpinBox, QDateEdit, QTimeEdit, QDateTimeEdit {{background-color: {SURFACE};
+QLineEdit, QTextEdit, QPlainTextEdit, QSpinBox, QDoubleSpinBox, QDateEdit, QTimeEdit, QDateTimeEdit, QKeySequenceEdit {{background-color: {SURFACE};
     color: {ON_SURFACE};
     border: 1px solid {OUTLINE};
     border-radius: 6px;
     padding: {PADDING_V}px {PADDING_H}px;}}
 QLineEdit:focus, QTextEdit:focus, QPlainTextEdit:focus, QSpinBox:focus, QDoubleSpinBox:focus,
-QDateEdit:focus, QTimeEdit:focus, QDateTimeEdit:focus {{border: 2px solid {PRIMARY};
+QDateEdit:focus, QTimeEdit:focus, QDateTimeEdit:focus, QKeySequenceEdit:focus {{border: 2px solid {PRIMARY};
     outline: none;}}
 /* Placeholder text (Qt 5.12+ / 6) */
 QLineEdit::placeholder, QTextEdit[placeholderText], QPlainTextEdit[placeholderText] {{color: rgba( {ON_SURFACE}, 0.60 );}}

--- a/src/q_materialise/demo.py
+++ b/src/q_materialise/demo.py
@@ -24,13 +24,12 @@ Notes
 from __future__ import annotations
 
 import sys
-from dataclasses import dataclass
 from typing import Iterable, Optional
 
 from PySide6.QtTest import QTest
 
 # QMaterialise — auto-selects available Qt binding
-from .core import inject_style, list_styles, get_style  # type: ignore
+from .core import inject_style, list_styles  # type: ignore
 
 # We'll primarily target PySide6 APIs. If a different binding is present,
 # q_materialise.binding can be used, but importing from PySide6 directly works
@@ -189,15 +188,20 @@ class InputsPageC(QtWidgets.QWidget):
         add_section(vbox, "QDateTimeEdit", dte)
 
         # Combo, LCD & KeySequence
-        combo = QtWidgets.QComboBox(); combo.addItems(["Foo","Bar","Baz"])
-        lcd   = QtWidgets.QLCDNumber(); lcd.display(1234)
-        kse   = QtWidgets.QKeySequenceEdit(); kse.setKeySequence(QtGui.QKeySequence("Ctrl+Shift+K"))
+        combo = QtWidgets.QComboBox()
+        combo.addItems(["Foo", "Bar", "Baz"])
+        lcd = QtWidgets.QLCDNumber()
+        lcd.display(1234)
+        lcd.setSegmentStyle(
+            QtWidgets.QLCDNumber.Flat
+        )  # Use flat segments so QSS colors apply
+        kse = QtWidgets.QKeySequenceEdit()
+        kse.setKeySequence(QtGui.QKeySequence("Ctrl+Shift+K"))
         add_section(vbox, "QComboBox", combo)
         add_section(vbox, "QLCDNumber", lcd)
         add_section(vbox, "QKeySequenceEdit", kse)
 
         vbox.addStretch(1)
-
 
 
 class ViewsPageA(QtWidgets.QWidget):
@@ -507,7 +511,6 @@ class ContainersPage(QtWidgets.QWidget):
         add_section(vbox, "Scroll Bars", scrollbars)
 
         vbox.addStretch(1)
-
 
 
 class MenusToolbarsPage(QtWidgets.QWidget):

--- a/tests/test_stylesheet.py
+++ b/tests/test_stylesheet.py
@@ -60,6 +60,19 @@ class TestStyleSheet(unittest.TestCase):
         qss = self._patched_qss()
         self.assertRegex(qss, r"QMenu \{[^}]*border: 1px solid")
 
+    def test_lcd_uses_flat_segments(self) -> None:
+        """Ensure QLCDNumber uses flat segments for correct coloring."""
+        qss = self._patched_qss()
+        self.assertRegex(
+            qss,
+            r"QLCDNumber \{[^}]*qproperty-segmentStyle: QLCDNumber::Flat;",
+        )
+
+    def test_keysequenceedit_included(self) -> None:
+        """Verify QKeySequenceEdit receives line edit styling."""
+        qss = self._patched_qss()
+        self.assertIn("QKeySequenceEdit", qss)
+
 
 if __name__ == "__main__":  # pragma: no cover - manual execution
     unittest.main()


### PR DESCRIPTION
## Summary
- ensure line-edit styling covers QKeySequenceEdit widgets
- render QLCDNumber with flat segments for consistent colors
- add tests for LCD segment style and key sequence styling

## Testing
- `ruff check --fix src/q_materialise/core.py tests/test_stylesheet.py`
- `ruff check src/q_materialise/demo.py --extend-ignore=E701,E702`
- `black src/q_materialise/core.py tests/test_stylesheet.py`
- `black src/q_materialise/demo.py --line-ranges 188-201`
- `PYTHONPATH=src pytest tests/test_stylesheet.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6898b5f4cdd08322af488ce00ce3c33b