### PR TITLE
fix: render lcd digits with theme colors

### DIFF
--- a/src/q_materialise/core.py
+++ b/src/q_materialise/core.py
@@ -939,6 +939,33 @@ QLabel[bold="true"] {{font-weight: 600;}}
     return qss_template.format(**variables)
 
 
+def _style_lcd_numbers(app: QtWidgets.QApplication, style: Style) -> None:
+    """Ensure ``QLCDNumber`` widgets use flat segments and theme colours.
+
+    Qt does not fully honour stylesheets for LCD widgets, particularly for
+    segment rendering. This helper updates any existing ``QLCDNumber`` in the
+    application so that their digits are drawn using the theme's surface and
+    text colours.
+
+    Args:
+        app: The running :class:`~PySide6.QtWidgets.QApplication`.
+        style: The :class:`~q_materialise.style.Style` supplying colours.
+    """
+
+    for widget in app.allWidgets():
+        if isinstance(widget, QtWidgets.QLCDNumber):
+            widget.setSegmentStyle(QtWidgets.QLCDNumber.SegmentStyle.Flat)
+            palette = widget.palette()
+            palette.setColor(
+                QtGui.QPalette.ColorRole.Window, QtGui.QColor(style.surface)
+            )
+            palette.setColor(
+                QtGui.QPalette.ColorRole.WindowText,
+                QtGui.QColor(style.on_surface),
+            )
+            widget.setPalette(palette)
+
+
 def inject_style(
     app: QtWidgets.QApplication,
     style: Union[str, Style, Dict[str, Any]],
@@ -1047,6 +1074,7 @@ def inject_style(
     _apply_global_icon_tint(app, primary_color=the_style.primary, default_px=24)
 
     app.setStyleSheet(qss)
+    _style_lcd_numbers(app, the_style)
 
 
 def export_style(

--- a/tests/test_lcd_widget.py
+++ b/tests/test_lcd_widget.py
@@ -1,0 +1,36 @@
+import os
+import sys
+
+# Use the offscreen platform to run Qt without a display.
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+# Remove any stubbed modules from other tests so real PySide6 can be loaded.
+for name in [
+    m for m in list(sys.modules) if m.startswith(("PySide6", "q_materialise"))
+]:
+    sys.modules.pop(name)
+
+from PySide6 import QtGui, QtWidgets  # type: ignore  # noqa: E402
+from q_materialise.core import get_style, inject_style, list_styles  # noqa: E402
+
+
+def test_lcd_numbers_use_theme_colours() -> None:
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    style_name = list_styles()[0]
+    style = get_style(style_name)
+
+    lcd = QtWidgets.QLCDNumber()
+    lcd.display(42)
+
+    inject_style(app, style_name)
+
+    assert lcd.segmentStyle() == QtWidgets.QLCDNumber.SegmentStyle.Flat
+    palette = lcd.palette()
+    assert (
+        palette.color(QtGui.QPalette.ColorRole.WindowText).name().lower()
+        == style.on_surface.lower()
+    )
+    assert (
+        palette.color(QtGui.QPalette.ColorRole.Window).name().lower()
+        == style.surface.lower()
+    )


### PR DESCRIPTION
## Summary
- ensure QLCDNumber widgets use flat segments and palette colours from the active theme
- update inject_style to apply LCD styling
- add regression test covering LCD segment style and colours

## Testing
- `ruff check --fix src/q_materialise/core.py tests/test_lcd_widget.py`
- `black src/q_materialise/core.py tests/test_lcd_widget.py`
- `PYTHONPATH=src pytest tests/test_stylesheet.py -q`
- `QT_QPA_PLATFORM=offscreen PYTHONPATH=src pytest tests/test_lcd_widget.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6898b5f4cdd08322af488ce00ce3c33b